### PR TITLE
fix: datetime cached file list

### DIFF
--- a/flush-opcache/admin/class-flush-opcache-cached-files-list.php
+++ b/flush-opcache/admin/class-flush-opcache-cached-files-list.php
@@ -187,7 +187,8 @@ class Flush_Opcache_Cached_Files_List extends WP_List_Table {
 				break; // phpcs:ignore
 			case 'timestamp':
 			case 'last_used_timestamp':
-				return date_i18n( 'Y/m/d g:i:s A', $item[ $column_name ] );
+				$offset = get_option( 'gmt_offset' ) * HOUR_IN_SECONDS;
+				return date_i18n( 'Y/m/d g:i:s A', $item[ $column_name ] + $offset );
 				break; // phpcs:ignore
 			default:
 				return $item[ $column_name ];

--- a/flush-opcache/flush-opcache.php
+++ b/flush-opcache/flush-opcache.php
@@ -21,7 +21,7 @@ if ( ! defined( 'WPINC' ) ) {
 	die;
 }
 
-define( 'FLUSH_OPCACHE_VERSION', '4.1.2' );
+define( 'FLUSH_OPCACHE_VERSION', '4.1.3' );
 define( 'FLUSH_OPCACHE_NAME', 'flush-opcache' );
 
 require plugin_dir_path( __FILE__ ) . 'includes/class-flush-opcache.php';

--- a/flush-opcache/readme.txt
+++ b/flush-opcache/readme.txt
@@ -3,8 +3,8 @@ Contributors: mnttech
 Tags: opcache, cache, flush, php, multisite
 Requires at least: 5.5
 Requires PHP: 7.2
-Tested up to: 5.8
-Stable tag: 4.1.2
+Tested up to: 5.9
+Stable tag: 4.1.3
 License: GPLv2
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -46,6 +46,9 @@ As usual...
 5. Cached files tab
 
 == Changelog ==
+
+= 4.1.3 =
+* Fix a bug on datetime in cached file list
 
 = 4.1.2 =
 * Fix a bug with ABSPATH when WordPress uses its own directory


### PR DESCRIPTION
https://wordpress.org/support/topic/wp-opcache-using-wrong-time-zonw/