### PR TITLE
feat: detect opcache

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,3 +39,8 @@ tests: ## Run all phpcs tests
 		--standard=WordPress \
 		flush-opcache/
 	pre-commit run --all-files
+
+remove-docker-data: ## Remove all data related to docker compose
+	docker compose down
+	docker volume rm wordpress-opcache-plugin_wp_data
+	sudo rm -rf ./db

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,8 +12,8 @@ services:
     ports:
       - 80:80
     volumes:
-      - wp_data:/var/www/html
-      - ./flush-opcache:/var/www/html/wp-content/plugins/flush-opcache
+      - wp_data:/var/www/html:rw
+      - ./flush-opcache:/var/www/html/wp-content/plugins/flush-opcache:ro
     healthcheck:
       test: ["CMD", "/bin/bash", "-c", "curl -s -o /dev/null http://localhost"]
       interval: 10s
@@ -43,7 +43,7 @@ services:
   wp-cli:
     container_name: wp-cli
     image: wordpress:${WP_CLI_VERSION}
-    user: www-data
+    user: 33:33
     environment:
       WORDPRESS_DB_HOST: ${WORDPRESS_DB_HOST}
       WORDPRESS_DB_USER: ${WORDPRESS_DB_USER}
@@ -51,8 +51,8 @@ services:
       WORDPRESS_DB_NAME: ${WORDPRESS_DB_NAME}
       WORDPRESS_DEBUG: ${WORDPRESS_DEBUG}
     volumes:
-      - wp_data:/var/www/html
-      - ./flush-opcache:/var/www/html/wp-content/plugins/flush-opcache
+      - wp_data:/var/www/html:rw
+      - ./flush-opcache:/var/www/html/wp-content/plugins/flush-opcache:ro
     command:
       - /bin/bash
       - -c
@@ -63,8 +63,11 @@ services:
           --title=dev \
           --admin_user=admin \
           --admin_password=notsecurepassword \
-          --admin_email=nierdz@example.com;
+          --admin_email=nierdz@example.com
         wp plugin activate flush-opcache
+        rm -rf /var/www/html/wp-content/themes/{twentytwentythree,twentytwentyfour}/
+        rm -rf /var/www/html/wp-content/plugins/{akismet,hello.php}/
+        wp theme update --all
 
 volumes:
   wp_data:

--- a/flush-opcache/admin/class-flush-opcache-admin.php
+++ b/flush-opcache/admin/class-flush-opcache-admin.php
@@ -254,16 +254,13 @@ class Flush_Opcache_Admin {
 		if ( ! is_user_logged_in() || ! is_admin_bar_showing() ) {
 			return false;
 		}
-		if ( ! is_admin() ) {
-			return false;
-		}
 		if ( get_site_option( 'flush-opcache-hide-button' ) === '1' ) {
 			return false;
 		}
-		$base_url   = remove_query_arg( 'settings-updated' );
-		$flush_url  = add_query_arg( array( 'flush_opcache_action' => 'flushopcacheall' ), $base_url );
-		$nonced_url = wp_nonce_url( $flush_url, 'flush_opcache_all' );
-		if ( ( is_multisite() && is_super_admin() && is_main_site() ) || ( ! is_multisite() && is_admin() ) ) {
+		if ( current_user_can( 'activate_plugins' ) ) {
+			$base_url   = remove_query_arg( 'settings-updated' );
+			$flush_url  = add_query_arg( array( 'flush_opcache_action' => 'flushopcacheall' ), $base_url );
+			$nonced_url = wp_nonce_url( $flush_url, 'flush_opcache_all' );
 			$wp_admin_bar->add_menu(
 				array(
 					'parent' => '',
@@ -273,6 +270,8 @@ class Flush_Opcache_Admin {
 					'href'   => $nonced_url,
 				)
 			);
+		} else {
+			return false;
 		}
 	}
 

--- a/flush-opcache/admin/class-flush-opcache-admin.php
+++ b/flush-opcache/admin/class-flush-opcache-admin.php
@@ -88,11 +88,13 @@ class Flush_Opcache_Admin {
 			echo '<div class="notice notice-error">
               <p>' . esc_html__( 'You do not have the Zend OPcache extension loaded, you need to install it to use this plugin.', 'flush-opcache' ) . '</p>
             </div>';
+			return false;
 		}
 		if ( ! opcache_get_status() ) {
 			echo '<div class="notice notice-error">
               <p>' . esc_html__( 'Zend OPcache is loaded but not activated. You need to set opcache.enable=1 in your php.ini', 'flush-opcache' ) . '</p>
             </div>';
+			return false;
 		}
 		$current_tab = $this->manage_tabs();
 		switch ( $current_tab ) {


### PR DESCRIPTION
- Ensure to not continue if `OPcache` is disabled or not installed to avoid printing PHP errors.
- Ensure user is admin or superadmin to display flush button in admin bar.