### PR TITLE
Fix the submenu for WordPress MultiSite

### DIFF
--- a/flush-opcache/admin/class-flush-opcache-admin.php
+++ b/flush-opcache/admin/class-flush-opcache-admin.php
@@ -311,16 +311,19 @@ class Flush_Opcache_Admin {
 	 */
 	public function flush_opcache_reset() {
 		$opcache_scripts = array();
-		if ( function_exists( 'opcache_get_status' ) ) {
-			try {
-				$raw = opcache_get_status( true );
-				if ( array_key_exists( 'scripts', $raw ) ) {
-					foreach ( $raw['scripts'] as $script ) {
-						/* Remove files outside of WP */
-						if ( false === strpos( $script['full_path'], get_home_path() ) && false === strpos( $script['full_path'], ABSPATH ) ) {
-							continue;
-						}
-						array_push( $opcache_scripts, $script['full_path'] );
+                if ( function_exists( 'opcache_get_status' ) ) {
+                        try {
+                                $raw = opcache_get_status( true );
+                                if ( is_array( $raw ) && isset( $raw['scripts'] ) && is_array( $raw['scripts'] ) ) {
+                                        foreach ( $raw['scripts'] as $script ) {
+                                                if ( ! is_array( $script ) || empty( $script['full_path'] ) ) {
+                                                        continue;
+                                                }
+                                                /* Remove files outside of WP */
+                                                if ( false === strpos( $script['full_path'], get_home_path() ) && false === strpos( $script['full_path'], ABSPATH ) ) {
+                                                        continue;
+                                                }
+                                                array_push( $opcache_scripts, $script['full_path'] );
 					}
 				}
 			} catch ( \Throwable $e ) {

--- a/flush-opcache/admin/class-flush-opcache-admin.php
+++ b/flush-opcache/admin/class-flush-opcache-admin.php
@@ -57,18 +57,19 @@ class Flush_Opcache_Admin {
 	/**
 	 * Generate menu pages in admin area
 	 */
-	public function flush_opcache_admin_menu() {
-		if ( is_multisite() && is_super_admin() && is_main_site() ) {
-			add_management_page(
-				__( 'WP OPcache Settings', 'flush-opcache' ),
-				__( 'WP OPcache', 'flush-opcache' ),
-				'manage_network_options',
-				'flush-opcache',
-				array( $this, 'flush_opcache_admin_page' )
-			);
-		} elseif ( ! is_multisite() && is_admin() ) {
-			add_management_page(
-				__( 'WP OPcache Settings', 'flush-opcache' ),
+        public function flush_opcache_admin_menu() {
+                if ( is_multisite() && is_super_admin() && is_main_site() ) {
+                        add_submenu_page(
+                                'settings.php',
+                                __( 'WP OPcache Settings', 'flush-opcache' ),
+                                __( 'WP OPcache', 'flush-opcache' ),
+                                'manage_network_options',
+                                'flush-opcache',
+                                array( $this, 'flush_opcache_admin_page' )
+                        );
+                } elseif ( ! is_multisite() && is_admin() ) {
+                        add_management_page(
+                                __( 'WP OPcache Settings', 'flush-opcache' ),
 				__( 'WP OPcache', 'flush-opcache' ),
 				'manage_options',
 				'flush-opcache',


### PR DESCRIPTION
I think this should fix the problem with the WordPress MultiSite menu. It appears at the Settings section, because there is no Tools section in WPMS.